### PR TITLE
Added additional detection for ebooks

### DIFF
--- a/GoodreadsRatingsForAmazon/content.js
+++ b/GoodreadsRatingsForAmazon/content.js
@@ -135,7 +135,7 @@ function getASIN() {
 		logex("getASIN", error);
 	}
 
-	// Limpiamos duplicados y vacios
+	// Remove duplicates and empty entries
 	var filteredAsin = asin.filter(function (value, index, inputArray) {
 		return value != null && value != "" &&
 			(inputArray.indexOf(value) === index);
@@ -450,7 +450,7 @@ function checkIfBook() {
 	// Audible
 	if (isAudibleCom) return window.location.href.indexOf("audible.com/pd") > 0;
 	// Amazon
-	var bookDetectionIdArray = ["ebooksImageBlockOuter", "booksTitle", "bookEdition", "pBookUpsellBorrowButton", "booksImageBlock_feature_div", "pbooksReadSampleButton-announce", "rpi-attribute-book_details-fiona_pages", "rpi-attribute-book_details-customer_recommended_age", "rpi-attribute-book_details-isbn13"];
+	var bookDetectionIdArray = ["ebooksImageBlockOuter", "booksTitle", "bookEdition", "pBookUpsellBorrowButton", "booksImageBlock_feature_div", "pbooksReadSampleButton-announce", "rpi-attribute-book_details-fiona_pages", "rpi-attribute-book_details-ebook_pages", "rpi-attribute-book_details-customer_recommended_age", "rpi-attribute-book_details-isbn13"];
 	return SelectById(bookDetectionIdArray) !== null;
 }
 


### PR DESCRIPTION
I had an issue with some Kindle ebooks that were not detected correctly by the script when using the German store (e.g. <https://www.amazon.de/Power-Geography-Much-Anticipated-Bestseller-Prisoners-ebook/dp/B08SGJ9WHG/>). From my observation, that store page did not have any of the IDs that are used to detect if the product page is of an book, so I added the `rpi-attribute-book_details-ebook_pages` ID which seems to be unique to ebooks and similar to the existing `rpi-attribute-book_details-fiona_pages` ID.

While debugging the extension, I also found a comment in Spanish which I translated to English.